### PR TITLE
AIW-xxx Rename /readyz to /ready to match tutorial documentation

### DIFF
--- a/javascript/hello-world/Dockerfile
+++ b/javascript/hello-world/Dockerfile
@@ -14,7 +14,7 @@ RUN apk update \
   && apk add --no-cache libc6-compat
 RUN npm install
 
-ENV VERITONE_WEBHOOK_READY="http://0.0.0.0:8080/readyz"
+ENV VERITONE_WEBHOOK_READY="http://0.0.0.0:8080/ready"
 ENV VERITONE_WEBHOOK_PROCESS="http://0.0.0.0:8080/process"
 
 COPY --from=vt-engine-toolkit /opt/aiware/engine /opt/aiware/engine

--- a/javascript/hello-world/index.js
+++ b/javascript/hello-world/index.js
@@ -11,7 +11,7 @@ let server = app.listen( 8080 );
 server.setTimeout( 10 * 60 * 1000 );
 
 // READY WEBHOOK
-app.get('/readyz', (req, res) => {
+app.get('/ready', (req, res) => {
     res.status(200).send('OK');
 });
 


### PR DESCRIPTION
Kas, I think this is a no-brainer, but just wanted to make sure I wasn't missing anything. I noted while going through the tutorial that the docs.veritone.com site changed /readyz to /ready, and I just wanted this to match.