### PR TITLE
Deploy update for python/sentiment from engine monorepo

### DIFF
--- a/python/sentiment/Makefile
+++ b/python/sentiment/Makefile
@@ -1,8 +1,7 @@
-# Template Makefile
-# Adjust this Makefile to suit your engine's needs, but this template includes
+# Adjust this Makefile to suit your engine's needs.
 
 # Name of this engine as provided by the Veritone Developer App under the build instructions
-VDA_NAME = "sentiment-sample-chunk-v-3"
+ENGINE_NAME = "YOUR-ENGINE-NAME"
 
 #
 # BUILDING targets
@@ -35,18 +34,11 @@ test: install
 #
 # ENGINE targets
 #
-.PHONY: engine docker test-image publish deploy deploy-%
+.PHONY: engine docker
 
 ## Build the engine
 engine: compile
 
 ## Build the docker image
 docker: 
-	docker build --tag=${VDA_NAME} .
-
-# start the engine in the test framework
-up-test:
-	docker run --rm -e "VERITONE_TESTMODE=true" -p 9090:9090 -p 8080:8080 $(VDA_NAME)
-
-# rebuild and start the engine in the test framework
-up-retest: docker up-test
+	docker build --tag=${ENGINE_NAME} .

--- a/python/sentiment/README.md
+++ b/python/sentiment/README.md
@@ -1,8 +1,8 @@
 # Sentiment engine
 
-Runs NLTK Sentiment analysis on English documents in either text or vtn-standard transcritpion format. 
+Runs NLTK Sentiment analysis on English documents in either text or vtn-standard transcritpion format.
 
-If the input is a text document, it is parsed into sentences, then each sentence is analyzed for sentiment. 
+If the input is a text document, it is parsed into sentences, then each sentence is analyzed for sentiment.
 The output is a vtn-standard file that contains each sentence as an `object` with the `sentiment` analysis.
 
 If the input is a vtn-standard document, then 3 different analyses are performed: for each word, for each
@@ -10,16 +10,16 @@ sentence, and for the entire document. The output is the same as the input, only
 added. Each word has a `sentiment` analysis, each sentence is added as an `object` with analysis, and the
 entire document has a `sentiment` analysis at the root level.
 
-| | | 
-| --- | --- |
-| __Language__: | Python |
-| __Mode__: | Chunk |
-| __Class__: | Text |
-| __Category__: | Sentiment |
+|               |           |
+| ------------- | --------- |
+| **Language**: | Python    |
+| **Mode**:     | Chunk     |
+| **Class**:    | Text      |
+| **Category**: | Sentiment |
 
 ## Example TEXT file
 
-### Input: 
+### Input:
 
 ```
 That's pretty good! But people still don't like it.
@@ -29,17 +29,17 @@ That's pretty good! But people still don't like it.
 
 ```
 {
-  'sentiment': {'positiveValue': 0.441, 'negativeValue': 0.145}, 
+  'sentiment': {'positiveValue': 0.441, 'negativeValue': 0.145},
   'object': [
-    {'type': 'text', 'text': "That's pretty good !", 'sentiment': {'positiveValue': 0.865, 'negativeValue': 0.0}}, 
+    {'type': 'text', 'text': "That's pretty good !", 'sentiment': {'positiveValue': 0.865, 'negativeValue': 0.0}},
     {'type': 'text', 'text': "But people still don't like it .", 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.297}}
-  ] 
+  ]
 }
 ```
 
 ## Example JSON file
 
-### Input: 
+### Input:
 
 ```
 {
@@ -63,94 +63,108 @@ That's pretty good! But people still don't like it.
 
 ```
 {
-  'sentiment': {'positiveValue': 0.441, 'negativeValue': 0.145}, 
+  'sentiment': {'positiveValue': 0.441, 'negativeValue': 0.145},
   'object': [
-    {'type': 'text', 'text': "That's pretty good !", 'sentiment': {'positiveValue': 0.865, 'negativeValue': 0.0}}, 
+    {'type': 'text', 'text': "That's pretty good !", 'sentiment': {'positiveValue': 0.865, 'negativeValue': 0.0}},
     {'type': 'text', 'text': "But people still don't like it .", 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.297}}
   ],
   'series': [
-    {'words': [{'word': "That's"}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': 'pretty'}], 'sentiment': {'positiveValue': 1.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': 'good'}], 'sentiment': {'positiveValue': 1.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': '!'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': 'But'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': 'people'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': 'still'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': "don't"}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': 'like'}], 'sentiment': {'positiveValue': 1.0, 'negativeValue': 0.0}}, 
-    {'words': [{'word': 'it'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}}, 
+    {'words': [{'word': "That's"}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}},
+    {'words': [{'word': 'pretty'}], 'sentiment': {'positiveValue': 1.0, 'negativeValue': 0.0}},
+    {'words': [{'word': 'good'}], 'sentiment': {'positiveValue': 1.0, 'negativeValue': 0.0}},
+    {'words': [{'word': '!'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}},
+    {'words': [{'word': 'But'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}},
+    {'words': [{'word': 'people'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}},
+    {'words': [{'word': 'still'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}},
+    {'words': [{'word': "don't"}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}},
+    {'words': [{'word': 'like'}], 'sentiment': {'positiveValue': 1.0, 'negativeValue': 0.0}},
+    {'words': [{'word': 'it'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}},
     {'words': [{'word': '.'}], 'sentiment': {'positiveValue': 0.0, 'negativeValue': 0.0}}
-  ] 
+  ]
 }
 ```
 
-## Get started
+## Create a new engine with Veritone
 
-1. Clone this project from github to your local machine.
-1. `cd` to the directory with this README
-1. Run `make test` to verify that the unit tests pass
-2. Run `make docker` to build the docker image for the engine
-3. Run `make up-test` to launch the docker image in test mode
-   1. Go to http://localhost:9090/ to see the test console and verify that all indicators are green.
-      Note that the engine takes 5 seconds to "warm up," which you can see in the Ready Webhook Test.
-   2. You can test the engine manually by filling out the **Process webhook test** form. 
-      You can choose any local jpg or gif file to see the exif information for that file 
-      (make sure the MIME type matches the file you are uplaoading). 
-      Note also that not all images contain EXIF data, but the ones in the testdata folder do.
-   3. When done, hit ctrl-C in the running terminal window.
+Log on to the Veritone developer environment (developer.veritone.com) to work with your engine.
 
-## Register engine with Veritone
-
-Now that you have a working engine, the next step is to upload it to Veritone. 
-Log on to the Veritone developer environment (developer.veritone.com) to experiment with your engine.
-
-1. Log on to the environment
-1. Click New > Engine to create a new engine
-1. Select the Cognition type of the engine.
-   1. For this test engine select Text > Sentiment (or whatever you want)
-1. Select the Engine Mode
+1. Log on 
+2. Click New > Engine to create a new engine
+3. Select the Cognition type of the engine.
+   1. For this test engine select Text > Sentiment
+4. Select the Engine Mode
    1. This engine is a "chunk" engine, also known as a "segment" engine
-1. Define the input types
+5. Define the input types
    1. This engine can process TEXT and JSON Files, so select `text/plain` and `application/json`
-      (pro tip: the order of selection is important, because the first one you click on becomes the "preferred" type for your engine, so select `text/plain` first.)
-2. This engine has one custom field, so we're going to create a field called `analyze`. Set the field info to document that this field
-   can contain one or more of the values `word`, `sentence`, and `document` to control what level of sentiment analysis is performed. The
+      (Pro tip: the order of selection is important, because the first one you click on becomes
+      the "preferred" type for your engine, so select `text/plain` first.)
+6. This engine has one custom field, so we're going to create a field called `analyze`. Set the
+   field info to document that this field can contain one or more of the values `word`,
+   `sentence`, and `document` to control what level of sentiment analysis is performed. The
    default is all three: `word,sentence,document`.
-   1. The "Field info" is the only documentation that most users will have for the field, so make sure it is meaningful and not just a restatement of the name. 
-3. Upload single engine templates
-   1. These templates allow simpler launching of your engine through the `launchSingleEngineJob` GraphQL interface, as 
-      well as making the engine available for running in the CMS environment.
-   2. Creating these templates is an advanced operation, and you can leave these blank for now 
-4. Select the Engine Category
-   1. Since this is a simple container that requires no external access, use "Network Isolated"
-5. Fill out the Engine Information
-   1. The name of the engine will be displayed in the interface, and I recommend something that is consise, but clear, like "Sentiment-Example-V3."
-      You may want to also add your initials or name since this is an example engine and there may be multiple version if different people in your organization experiment with this sample code.
+   1. The "Field info" is the only documentation that most users will have for the field, so
+      make sure it is meaningful and not just a restatement of the name.
+7. Upload single engine templates
+   1. These templates allow simpler launching of your engine through the `launchSingleEngineJob`
+      GraphQL interface, as well as making the engine available for running in the CMS
+      environment.
+   2. Creating these templates is an advanced operation, and you can leave these blank for now
+8. Select the Engine Category
+   1. Since this is a self-contained engine that requires no external access, use "Network Isolated"
+9. Fill out the Engine Information
+   1. The name of the engine will be displayed in the interface, and I recommend something that
+      is consise, but clear, like "Sentiment-Example-V3." You may want to also add your initials
+      or name since this is an example engine and there may be multiple version if different
+      people in your organization experimenting with this sample code.
    2. Fill out the rest of the information as it pertains to your organization.
    3. This engine does not require a library.
    4. The use case for this engine is "Perform sentiment analysis on text" (or something similar)
 
+Once the engine is created, you will be shown a page that describes how to upload a build. We're going
+to pause here and get the engine ready. However, we did this part first because you will need to
+know your Engine ID in order to configure your engine correctly. Under the engine name will be the UUID
+of your engine. Copy this value.
+
+## Get started
+
+1. Clone this project from github to your local machine.
+2. `cd` to the directory with this README
+3. Edit the `manifest.json` file
+   1. Set the "engineId" field to your ID
+   2. Set the "url" field to where you will be committing your code. Since this is just a sample engine, you can
+      just leave this as it is. Note, however, that this does need to be a valid URL, even if it doesn't refer
+      to anything.
+4. Edit the `Makefile` file
+   1. Set the ENGINE_NAME to the name of your engine. On the Veritone Developer site you will see instructions
+      for how to build your engine. These will include something like `docker build -t sentiment-example-v3 .`, and
+      this is the name of your engine. You don't have to use the makefile, but if you elect to do so, then
+      having the name match the Developer site will help maintain consistency. If you want to use something else
+      (like the engine ID) you can do that, you will just have to use that name instead of the names in the rest of
+      the instructions.
+5. Run `make test` to verify that the unit tests pass
+6. Run `make docker` to build the docker image for the engine
+
+Once you have successfully run `make docker` you can run `docker images` and will see your image
+
 ## Upload your engine to Veritone
 
-Now that your engine is registered with Veritone, you need to build it and upload it to the Veritone docker repository.
-On developer.veritone.com, go to engines and search for your engine. 
+Now that your engine is built and registred with Veritone, you need to upload it to the Veritone docker repository.
+On developer.veritone.com, go to engines and search for your engine.
 Click on it and you will see instructions on how to do this, so just follow them.
 
-Note that the name of your engine in the repository is probably different from the default name included in this sample.
-The Veritone name is derived from the name you typed during registration. 
-For convenience, you may want to change the name of your docker image in the Makefile.  
+Note that the name of your engine in the repository may be different from the default name included in this sample.
+The Veritone name is derived from the name you typed during registration.
 
-Note also that during the registration process, your engine was assigned an ID (a UUID) for identification within the aiWARE ecosystem.
-This UUID must be included in the manifest file that is included in your docker image.
-You can just edit the provided manifest.json file and insert your engine ID, or download a new manifest file from the website and replace the provided one.
+Also note that your engine will be identified as yours by the engineID in the manifest file, so ensure your 
+manifest.json file matches the website.
 
 ## Deploy your engine
 
 After you have pushed your engine to the docker.veritone.com repository.
 
 1. Refresh the "Builds" list on your engine page to see the new build.
-1. Click "SUBMIT" to submit your engine for approval.
-1. When your engine is approved, click "DEPLOY" to make it live in the aiWARE ecosystem. 
+2. Click "SUBMIT" to submit your engine for approval.
+3. When your engine is approved, click "DEPLOY" to make it live in the aiWARE ecosystem.
 
 ## Test your engine
 
@@ -161,7 +175,7 @@ Fill out the MIME type, and cacheURI fields (cacheURI is under "Set advanced fie
 
 ### In the Veritone ecosystem
 
-Once your engine is deployed, you can test it by sending it a job. 
+Once your engine is deployed, you can test it by sending it a job.
 Creating jobs is out of scope for this document, but you can find more information on the [Veritone Documents](https://docs.veritone.com/) site.
 
 However, a sample job may look like this
@@ -188,8 +202,8 @@ mutation (
         ]
       }
       {
-        # Chunk engine 
-        engineId: "8bdb0e3b-ff28-4f6e-a3ba-887bd06e6440"  
+        # Chunk engine
+        engineId: "8bdb0e3b-ff28-4f6e-a3ba-887bd06e6440"
         payload:{ ffmpegTemplate: "rawchunk" }
         executionPreferences: { parentCompleteBeforeStarting: true }
         ioFolders: [
@@ -203,20 +217,20 @@ mutation (
         payload: { analyze: "sentence,document" }
         executionPreferences: { parentCompleteBeforeStarting: true }
         ioFolders: [
-          { referenceId: "engine-in", mode: chunk, type: input } 
-          { referenceId: "engine-out", mode: chunk, type: output } 
+          { referenceId: "engine-in", mode: chunk, type: input }
+          { referenceId: "engine-out", mode: chunk, type: output }
        ]
       }
       {
         # output writer
-        engineId: "8eccf9cc-6b6d-4d7d-8cb3-7ebf4950c5f3"  
+        engineId: "8eccf9cc-6b6d-4d7d-8cb3-7ebf4950c5f3"
         executionPreferences: { parentCompleteBeforeStarting: true }
         ioFolders: [
-          { referenceId: "ow-in", mode: chunk, type: input } 
+          { referenceId: "ow-in", mode: chunk, type: input }
         ]
       }
     ]
-    
+
     ##Routes
     routes: [
       {  ## WSA --> chunkAudio

--- a/python/sentiment/manifest.json
+++ b/python/sentiment/manifest.json
@@ -1,6 +1,6 @@
 {
-  "engineId": "YOUR_ENGINE_ID",
-  "url": "YOUR_URL",
+  "engineId": "YOUR-ENGINE-ID",
+  "url": "https://github.com/YOUR-ENGINE-URL",
   "category": "Sentiment",
   "externalCalls": [],
   "outputFormats": ["application/json"],


### PR DESCRIPTION
This is an automatic deploy of the code from github.com/veritone/engines/engines/sample/python/sentiment to the public sample engine repository. Please review to ensure that the changes are appropriate for a public repository, and correct in the veritone/engines repo if not.