### PR TITLE
AWT-3073: Fixed NodeJS version to use cacheURI instead of a file.

### DIFF
--- a/javascript/hello-world/index.js
+++ b/javascript/hello-world/index.js
@@ -3,6 +3,7 @@
 const KeywordExtraction = require("./keyword-extraction.js"),
     express = require('express'),
     multer = require('multer'),
+    fetch = require('node-fetch-commonjs'),
     upload = multer({storage: multer.memoryStorage()}),
     app = express();
 
@@ -18,10 +19,16 @@ app.get('/ready', (req, res) => {
 // PROCESS WEBHOOK
 app.post('/process', chunkUpload, async (req, res)=>{
     try {
-        let buffer = req.file.buffer.toString();
+        const cacheUri = req.body.cacheURI;
+        console.log(`Reading from ${cacheUri}`);
+
+        const response = await fetch(cacheUri);
+        const buffer = await response.text();
+
         let output = KeywordExtraction.getOutput( buffer, null );
         return res.status(200).send( output );
     } catch (error) {
+        console.log(error);
         return res.status(500).send(error);
     }
 });

--- a/javascript/hello-world/package.json
+++ b/javascript/hello-world/package.json
@@ -11,6 +11,7 @@
   "license": "Apache 2.0",
   "dependencies": {
     "express": "^4.17.1",
-    "multer": "^1.4.1"
+    "multer": "^1.4.1",
+    "node-fetch-commonjs": "^3.1.1"
   }
 }


### PR DESCRIPTION
Fixed the NodeJS example for V3. It used to process a file instead of cacheURI.